### PR TITLE
fix: draft preview from panel not working

### DIFF
--- a/site/plugins/kirby-vite/routes.php
+++ b/site/plugins/kirby-vite/routes.php
@@ -20,9 +20,12 @@ return [
                 [$pageId] = $args;
             }
 
-            $page = page($pageId) ?? site()->errorPage();
-            $json = Page::render($page, 'json');
+            $page = kirby()->page($pageId);
+            if (!$page || !$page->isReadable()) {
+                $page = site()->errorPage();
+            };
 
+            $json = Page::render($page, 'json');
             return new Response($json, 'application/json');
         }
     ],
@@ -45,9 +48,12 @@ return [
                 $pageId = site()->homePageId();
             }
 
-            $page = page($pageId) ?? site()->errorPage();
-            $html = Page::render($page, 'html');
+            $page = kirby()->page($pageId);
+            if (!$page || !$page->isReadable()) {
+                $page = site()->errorPage();
+            };
 
+            $html = Page::render($page, 'html');
             return $html;
         }
     ]

--- a/site/plugins/kirby-vite/routes.php
+++ b/site/plugins/kirby-vite/routes.php
@@ -22,7 +22,7 @@ return [
 
             $page = kirby()->page($pageId);
             if (!$page || !$page->isReadable()) {
-                $page = site()->errorPage();
+                $page = kirby()->site()->errorPage();
             };
 
             $json = Page::render($page, 'json');
@@ -50,7 +50,7 @@ return [
 
             $page = kirby()->page($pageId);
             if (!$page || !$page->isReadable()) {
-                $page = site()->errorPage();
+                $page = kirby()->site()->errorPage();
             };
 
             $html = Page::render($page, 'html');


### PR DESCRIPTION
Draft previews are currently not working from within the panel, since the `page()` method is not able to find drafts. See https://getkirby.com/docs/reference/templates/helpers/page.

In order to only allow previews for logged in users the `isReadable()` method is used. See https://getkirby.com/docs/reference/objects/cms/page/is-readable.