### PR TITLE
Fix: broken routing when logged out

### DIFF
--- a/site/plugins/kirby-vite/routes.php
+++ b/site/plugins/kirby-vite/routes.php
@@ -21,7 +21,7 @@ return [
             }
 
             $page = kirby()->page($pageId);
-            if (!$page || !$page->isReadable()) {
+            if (!$page || !$page->isVerified(get('token'))) {
                 $page = kirby()->site()->errorPage();
             };
 
@@ -49,7 +49,7 @@ return [
             }
 
             $page = kirby()->page($pageId);
-            if (!$page || !$page->isReadable()) {
+            if (!$page || !$page->isVerified(get('token'))) {
                 $page = kirby()->site()->errorPage();
             };
 

--- a/src/hooks/useKirbyApi.js
+++ b/src/hooks/useKirbyApi.js
@@ -50,10 +50,14 @@ const apiUri = (path) => {
  * @param {boolean} [options.revalidate=false] Skip cache look-up and fetch page freshly
  * @returns {Promise<object|boolean>} The page's data or `false` if fetch request failed
  */
-const getPage = async (id, { revalidate = false } = {}) => {
+const getPage = async (id, { revalidate = false, token } = {}) => {
+  console.log(token);
+
   let page;
   const isCached = cache.has(id);
-  const targetUrl = apiUri(`${id}.json`);
+  const targetUrl = token
+    ? apiUri(`${id}.json?token=${token}`)
+    : apiUri(`${id}.json`);
 
   // Use cached page if present in the store, except when revalidating
   if (!revalidate && isCached) {

--- a/src/hooks/useKirbyApi.js
+++ b/src/hooks/useKirbyApi.js
@@ -48,6 +48,7 @@ const apiUri = (path) => {
  * @param {string} id The page to retrieve
  * @param {object} [options] Optional options
  * @param {boolean} [options.revalidate=false] Skip cache look-up and fetch page freshly
+ * @param {boolean} [options.token] Add a token to the request to fetch a draft preview
  * @returns {Promise<object|boolean>} The page's data or `false` if fetch request failed
  */
 const getPage = async (id, { revalidate = false, token = null } = {}) => {

--- a/src/hooks/useKirbyApi.js
+++ b/src/hooks/useKirbyApi.js
@@ -48,7 +48,7 @@ const apiUri = (path) => {
  * @param {string} id The page to retrieve
  * @param {object} [options] Optional options
  * @param {boolean} [options.revalidate=false] Skip cache look-up and fetch page freshly
- * @param {boolean} [options.token] Add a token to the request to fetch a draft preview
+ * @param {string} [options.token] Add a token to the request to fetch a draft preview
  * @returns {Promise<object|boolean>} The page's data or `false` if fetch request failed
  */
 const getPage = async (id, { revalidate = false, token } = {}) => {

--- a/src/hooks/useKirbyApi.js
+++ b/src/hooks/useKirbyApi.js
@@ -51,7 +51,7 @@ const apiUri = (path) => {
  * @param {boolean} [options.token] Add a token to the request to fetch a draft preview
  * @returns {Promise<object|boolean>} The page's data or `false` if fetch request failed
  */
-const getPage = async (id, { revalidate = false, token = null } = {}) => {
+const getPage = async (id, { revalidate = false, token } = {}) => {
   let page;
   const isCached = cache.has(id);
   const targetUrl = token

--- a/src/hooks/useKirbyApi.js
+++ b/src/hooks/useKirbyApi.js
@@ -50,9 +50,7 @@ const apiUri = (path) => {
  * @param {boolean} [options.revalidate=false] Skip cache look-up and fetch page freshly
  * @returns {Promise<object|boolean>} The page's data or `false` if fetch request failed
  */
-const getPage = async (id, { revalidate = false, token } = {}) => {
-  console.log(token);
-
+const getPage = async (id, { revalidate = false, token = null } = {}) => {
   let page;
   const isCached = cache.has(id);
   const targetUrl = token

--- a/src/hooks/usePage.js
+++ b/src/hooks/usePage.js
@@ -10,12 +10,15 @@ import { useAnnouncer, useKirbyApi } from "./";
  */
 export default (path) => {
   const router = useRouter();
-  const { path: currentPath } = useRoute();
+  const { path: currentPath, query } = useRoute();
   const { hasPage, getPage } = useKirbyApi();
   const { setAnnouncer } = useAnnouncer();
 
   // Build page id and trim leading or trailing slashes
   let id = (path ?? currentPath).replace(/^\/|\/$/g, "");
+
+  // Get token for draft previews
+  const token = query.token;
 
   // Fall back to homepage if id is empty
   if (!id) id = "home";
@@ -37,7 +40,7 @@ export default (path) => {
     // Check if cached page exists (otherwise skip SWR)
     const isCached = hasPage(id);
     // Get page from cache or freshly fetch it
-    const data = await getPage(id);
+    const data = await getPage(id, { token });
 
     if (!data) {
       page.__status = "error";


### PR DESCRIPTION
@johannschopplich 

I’ve just realised that the proposed draft preview fix earlier introduced a bug for logged out users, where all pages redirected to the error page.

Here `isReadable()` is replaced by `isVerified()`. In order to make this work, the query token needs to be attached to all `.json` requests as well. Otherwise the data could either not be fetched or would be publicly exposed.

https://getkirby.com/docs/reference/objects/cms/page/is-verified

Sorry for introducing the bug prior. This should fix it.